### PR TITLE
Broke out workspace controls into subunits. Conditionally display grid-related controls.

### DIFF
--- a/gui/src/WorkspaceView/WorkspaceViewControlPanel.tsx
+++ b/gui/src/WorkspaceView/WorkspaceViewControlPanel.tsx
@@ -1,9 +1,11 @@
-import { Checkbox, MenuItem, Radio, Select } from '@material-ui/core';
-import { JSONStringifyDeterministic } from 'figurl/viewInterface/kacheryTypes';
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent } from 'react';
 import { WorkspaceViewData } from 'VolumeViewData';
-import ZoomFactorControl, { ArrowScaleFactorControl, ArrowStrideControl, BrightnessFactorControl } from './controls/ZoomFactorControl';
-import { GridScalarValue, VectorFieldComponentName, vectorFieldComponentNames, WorkspaceViewSelection, WorkspaceViewSelectionAction } from './workspaceViewSelectionReducer';
+import GridFieldControls from './controls/GridFieldControls';
+import GridSelectionControls from './controls/GridSelectionControls';
+import PlaneViewControls from './controls/PlaneViewControls';
+import SurfaceSelectionControls from './controls/SurfaceSelectionControls';
+import ThreeDSceneControls from './controls/ThreeDSceneControls';
+import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from './workspaceViewSelectionReducer';
 
 type Props = {
     data: WorkspaceViewData
@@ -14,237 +16,42 @@ type Props = {
 }
 
 const WorkspaceViewControlPanel: FunctionComponent<Props> = ({data, selection, selectionDispatch}) => {
-    const handleSelectedGridChanged = useCallback((evt: React.ChangeEvent<{name?: string, value: any}>) => {
-        const a = evt.target.value as string
-        selectionDispatch({
-            type: 'setGrid',
-            gridName: a !== '<undefined>' ? a : undefined
-        })
-    }, [selectionDispatch])
-    const handleVectorFieldComponentChange = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const x = JSON.parse(e.target.value as string) as {gridVectorFieldName: string, componentName: VectorFieldComponentName}
-        selectionDispatch({
-            type: 'setGridScalar',
-            gridScalar: {type: 'vectorFieldComponent', gridVectorFieldName: x.gridVectorFieldName, componentName: x.componentName}
-        })
-    }, [selectionDispatch])
-    const handleScalarFieldChange = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const x = JSON.parse(e.target.value as string) as {gridScalarFieldName: string}
-        selectionDispatch({
-            type: 'setGridScalar',
-            gridScalar: {type: 'scalarField', gridScalarFieldName: x.gridScalarFieldName}
-        })
-    }, [selectionDispatch])
-    const handleVectorFieldArrowChange = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const gridVectorFieldName = e.target.value as string
-        selectionDispatch({
-            type: 'toggleGridArrowVectorField',
-            gridVectorFieldName
-        })
-    }, [selectionDispatch])
-    const handleToggleVisibleSurface = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const surfaceName = e.target.value as string
-        selectionDispatch({
-            type: 'toggleVisibleSurface',
-            surfaceName
-        })
-    }, [selectionDispatch])
-    const handleToggleShowReferencePlanes = useCallback(() => {
-        selectionDispatch({
-            type: 'toggleShowReferencePlanes'
-        })
-    }, [selectionDispatch])
-    const handleToggleTransparentReferencePlanes = useCallback(() => {
-        selectionDispatch({
-            type: 'toggleTransparentReferencePlanes'
-        })
-    }, [selectionDispatch])
-    const handleToggleShowReferenceLines = useCallback(() => {
-        selectionDispatch({
-            type: 'toggleShowReferenceLines'
-        })
-    }, [selectionDispatch])
-    const handlePlaneViewZoom = useCallback((direction: number) => {
-        selectionDispatch({
-            type: 'planeViewZoom',
-            direction
-        })
-    }, [selectionDispatch])
-    const handlePlaneViewBrighten = useCallback((direction: number) => {
-        selectionDispatch({
-            type: 'planeViewBrighten',
-            direction
-        })
-    }, [selectionDispatch])
-    const handlePlaneViewScaleArrows = useCallback((direction: number) => {
-        selectionDispatch({
-            type: 'planeViewScaleArrows',
-            direction
-        })
-    }, [selectionDispatch])
-    const handlePlaneViewAdjustArrowStride = useCallback((direction: number) => {
-        selectionDispatch({
-            type: 'planeViewAdjustArrowStride',
-            direction
-        })
-    }, [selectionDispatch])
+
+    const gridControls = selection.gridName ? [<GridFieldControls
+        data={data}
+        selection={selection}
+        selectionDispatch={selectionDispatch}
+    />,
+    <ThreeDSceneControls
+        selection={selection}
+        selectionDispatch={selectionDispatch}
+    />,
+    <PlaneViewControls
+        selection={selection}
+        selectionDispatch={selectionDispatch}
+    />] : []
     return (
         <div style={{padding: 10, overflowY: "auto"}}>
-
-            {/* Select grid */}
-            <div key="select-grid">
-                <h3>Grid</h3>
-                <Select
-                    value={selection.gridName || '<undefined>'}
-                    onChange={handleSelectedGridChanged}
-                >
-                    <MenuItem key="<undefined>" value="<undefined>">Select a grid</MenuItem>
-                    {
-                        data.grids.map(grid => (
-                            <MenuItem key={grid.name} value={grid.name}>{grid.name}</MenuItem>
-                        ))
-                    }
-                </Select>
-            </div>
-
-            {/* Grid vector fields */}
-            <div key="grid-vector-fields">
-                <h3>Grid vector fields</h3>
-                {
-                    data.gridVectorFields.filter(x => (x.gridName === selection.gridName)).map(x => (
-                        <div key={x.name}>
-                            <div key="grid-vector-field">{x.name}</div>
-                            <div style={{display: 'flex', flexDirection: 'row', flexWrap: 'wrap'}}>
-                            {
-                                vectorFieldComponentNames.map(a => (
-                                    <div key={a} style={{whiteSpace: 'nowrap'}}>
-                                        <Radio
-                                            value={JSON.stringify({gridVectorFieldName: x.name, componentName: a})}
-                                            checked={gridScalarsAreEqual(selection.gridScalar, {type: 'vectorFieldComponent', gridVectorFieldName: x.name, componentName: a})}
-                                            onChange={handleVectorFieldComponentChange}
-                                        /> {a}
-                                    </div>
-                                ))
-                            }
-                            </div>
-                            <div key="arrows">
-                                <Checkbox
-                                    value={x.name}
-                                    checked={selection.gridArrowVectorFieldName === x.name}
-                                    onChange={handleVectorFieldArrowChange}
-                                /> Arrows
-                            </div>
-                        </div>
-                    ))
-                }
-            </div>
-
-            {/* Grid scalar fields */}
-            <div key="grid-scalar-fields">
-                <h3>Grid scalar fields</h3>
-                {
-                    data.gridScalarFields.filter(x => (x.gridName === selection.gridName)).map(x => (
-                        <div key={x.name}>
-                            <div key="grid-scalar-field">{x.name}</div>
-                            <div>
-                                <Radio
-                                    value={JSON.stringify({gridScalarFieldName: x.name})}
-                                    checked={gridScalarsAreEqual(selection.gridScalar, {type: 'scalarField', gridScalarFieldName: x.name})}
-                                    onChange={handleScalarFieldChange}
-                                /> scalar
-                            </div>
-                        </div>
-                    ))
-                }
-            </div>
-
-            {/* Surfaces */}
-            <div key="surfaces">
-                <h3>Surfaces</h3>
-                {
-                    data.surfaces.map(x => (
-                        <div key={x.name}>
-                            <div key="surface">Surface: {x.name}</div>
-                            <div key="show">
-                                <Checkbox
-                                    value={x.name}
-                                    checked={(selection.visibleSurfaceNames || []).includes(x.name)}
-                                    onChange={handleToggleVisibleSurface}
-                                /> show surface
-                            </div>
-                            <div key="surface-vector-fields">
-                                {/* todo */}
-                            </div>
-                            <div key="surface-scalar-fields">
-                                {/* todo */}
-                            </div>
-                        </div>
-                    ))
-                }
-            </div>
-
-            {/* 3D Scene */}
-            <div key="3d-scene">
-                <h3>3D scene</h3>
-                <div>
-                    <Checkbox
-                        checked={selection.scene3DOpts.showReferencePlanes}
-                        onChange={handleToggleShowReferencePlanes}
-                    /> Show reference planes
-                </div>
-                <div>
-                    <Checkbox
-                        checked={selection.scene3DOpts.transparentReferencePlanes}
-                        onChange={handleToggleTransparentReferencePlanes}
-                    /> Transparent reference planes
-                </div>
-                <div>
-                    <Checkbox
-                        checked={selection.scene3DOpts.showReferenceLines}
-                        onChange={handleToggleShowReferenceLines}
-                    /> Show reference lines
-                </div>
-            </div>
-
-            {/* Plane views */}
-            <div key="plane-views">
-                <h3>Plane views</h3>
-                <ZoomFactorControl
-                    value={selection.planeViewOpts.zoomFactor}
-                    onZoom={handlePlaneViewZoom}
+            {
+                data.grids.length > 0 && 
+                <GridSelectionControls
+                    data={data}
+                    selection={selection}
+                    selectionDispatch={selectionDispatch}
                 />
-                <div>&nbsp;</div>
-                <BrightnessFactorControl
-                    value={selection.planeViewOpts.brightnessFactor}
-                    onBrighten={handlePlaneViewBrighten}
+            }
+
+            {
+                data.surfaces.length > 0 &&
+                <SurfaceSelectionControls
+                    data={data}
+                    selection={selection}
+                    selectionDispatch={selectionDispatch}
                 />
-                <div>&nbsp;</div>
-                <ArrowScaleFactorControl
-                    value={selection.planeViewOpts.arrowScaleFactor}
-                    onScaleArrows={handlePlaneViewScaleArrows}
-                />
-                <div>&nbsp;</div>
-                <ArrowStrideControl
-                    value={selection.planeViewOpts.arrowStride}
-                    onAdjustArrowStride={handlePlaneViewAdjustArrowStride}
-                />
-            </div>
+            }
+            {gridControls}
         </div>
     )
-}
-
-const gridScalarsAreEqual = (a: GridScalarValue | undefined, b: GridScalarValue | undefined) => {
-        if (!a) return false
-        if (!b) return false
-        return JSONStringifyDeterministic(a) === JSONStringifyDeterministic(b)
 }
 
 export default WorkspaceViewControlPanel

--- a/gui/src/WorkspaceView/controls/GridFieldControls.tsx
+++ b/gui/src/WorkspaceView/controls/GridFieldControls.tsx
@@ -1,0 +1,106 @@
+import { Checkbox, Radio } from '@material-ui/core';
+import { JSONStringifyDeterministic } from 'figurl/viewInterface/kacheryTypes';
+import React, { Fragment, FunctionComponent, useCallback } from 'react';
+import { WorkspaceViewData } from 'VolumeViewData';
+import { GridScalarValue, VectorFieldComponentName, vectorFieldComponentNames, WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+
+type GridFieldSelectionControlsProps = {
+    data: WorkspaceViewData
+    selection: WorkspaceViewSelection
+    selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+const GridFieldControls: FunctionComponent<GridFieldSelectionControlsProps> = (props: GridFieldSelectionControlsProps) => {
+    const { data, selection, selectionDispatch } = props
+
+    const handleVectorFieldComponentChange = useCallback((e: React.ChangeEvent<{
+        value: unknown
+    }>) => {
+        const x = JSON.parse(e.target.value as string) as {gridVectorFieldName: string, componentName: VectorFieldComponentName}
+        selectionDispatch({
+            type: 'setGridScalar',
+            gridScalar: {type: 'vectorFieldComponent', gridVectorFieldName: x.gridVectorFieldName, componentName: x.componentName}
+        })
+    }, [selectionDispatch])
+    const handleScalarFieldChange = useCallback((e: React.ChangeEvent<{
+        value: unknown
+    }>) => {
+        const x = JSON.parse(e.target.value as string) as {gridScalarFieldName: string}
+        selectionDispatch({
+            type: 'setGridScalar',
+            gridScalar: {type: 'scalarField', gridScalarFieldName: x.gridScalarFieldName}
+        })
+    }, [selectionDispatch])
+    const handleVectorFieldArrowChange = useCallback((e: React.ChangeEvent<{
+        value: unknown
+    }>) => {
+        const gridVectorFieldName = e.target.value as string
+        selectionDispatch({
+            type: 'toggleGridArrowVectorField',
+            gridVectorFieldName
+        })
+    }, [selectionDispatch])
+
+    return (
+        <Fragment>
+            {/* Grid vector fields */}
+            <div key="grid-vector-fields">
+                <h3>Grid vector fields</h3>
+                {
+                    data.gridVectorFields.filter(x => (x.gridName === selection.gridName)).map(x => (
+                        <div key={x.name}>
+                            <div key="grid-vector-field">{x.name}</div>
+                            <div style={{display: 'flex', flexDirection: 'row', flexWrap: 'wrap'}}>
+                            {
+                                vectorFieldComponentNames.map(a => (
+                                    <div key={a} style={{whiteSpace: 'nowrap'}}>
+                                        <Radio
+                                            value={JSON.stringify({gridVectorFieldName: x.name, componentName: a})}
+                                            checked={gridScalarsAreEqual(selection.gridScalar, {type: 'vectorFieldComponent', gridVectorFieldName: x.name, componentName: a})}
+                                            onChange={handleVectorFieldComponentChange}
+                                        /> {a}
+                                    </div>
+                                ))
+                            }
+                            </div>
+                            <div key="arrows">
+                                <Checkbox
+                                    value={x.name}
+                                    checked={selection.gridArrowVectorFieldName === x.name}
+                                    onChange={handleVectorFieldArrowChange}
+                                /> Arrows
+                            </div>
+                        </div>
+                    ))
+                }
+            </div>
+
+            {/* Grid scalar fields */}
+            <div key="grid-scalar-fields">
+                <h3>Grid scalar fields</h3>
+                {
+                    data.gridScalarFields.filter(x => (x.gridName === selection.gridName)).map(x => (
+                        <div key={x.name}>
+                            <div key="grid-scalar-field">{x.name}</div>
+                            <div>
+                                <Radio
+                                    value={JSON.stringify({gridScalarFieldName: x.name})}
+                                    checked={gridScalarsAreEqual(selection.gridScalar, {type: 'scalarField', gridScalarFieldName: x.name})}
+                                    onChange={handleScalarFieldChange}
+                                /> scalar
+                            </div>
+                        </div>
+                    ))
+                }
+            </div>
+        </Fragment>
+    )
+}
+
+const gridScalarsAreEqual = (a: GridScalarValue | undefined, b: GridScalarValue | undefined) => {
+    if (!a) return false
+    if (!b) return false
+    return JSONStringifyDeterministic(a) === JSONStringifyDeterministic(b)
+}
+
+export default GridFieldControls

--- a/gui/src/WorkspaceView/controls/GridSelectionControls.tsx
+++ b/gui/src/WorkspaceView/controls/GridSelectionControls.tsx
@@ -1,0 +1,41 @@
+import { MenuItem, Select } from '@material-ui/core';
+import React, { FunctionComponent, useCallback } from 'react';
+import { WorkspaceViewData } from 'VolumeViewData';
+import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+
+type GridSelectionProps = {
+    data: WorkspaceViewData
+    selection: WorkspaceViewSelection
+    selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+const GridSelectionControls: FunctionComponent<GridSelectionProps> = (props: GridSelectionProps) => {
+    const {data, selection, selectionDispatch } = props
+
+    const handleSelectedGridChanged = useCallback((evt: React.ChangeEvent<{name?: string, value: any}>) => {
+        const a = evt.target.value as string
+        selectionDispatch({
+            type: 'setGrid',
+            gridName: a !== '<undefined>' ? a : undefined
+        })
+    }, [selectionDispatch])
+
+    return (
+        <div key="select-grid">
+            <h3>Grid</h3>
+            <Select
+                value={selection.gridName || '<undefined>'}
+                onChange={handleSelectedGridChanged}
+            >
+                <MenuItem key="<undefined>" value="<undefined>">Select a grid</MenuItem>
+                {
+                    data.grids.map(grid => (
+                        <MenuItem key={grid.name} value={grid.name}>{grid.name}</MenuItem>
+                    ))
+                }
+            </Select>
+        </div>
+    )
+}
+
+export default GridSelectionControls

--- a/gui/src/WorkspaceView/controls/PlaneViewControls.tsx
+++ b/gui/src/WorkspaceView/controls/PlaneViewControls.tsx
@@ -1,0 +1,65 @@
+import React, { FunctionComponent, useCallback } from 'react';
+import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+import ZoomFactorControl, { ArrowScaleFactorControl, ArrowStrideControl, BrightnessFactorControl } from './ZoomFactorControl';
+
+type PlaneViewControlProps = {
+    selection: WorkspaceViewSelection
+    selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+
+const PlaneViewControls: FunctionComponent<PlaneViewControlProps> = (props: PlaneViewControlProps) => {
+    const {selection, selectionDispatch} = props
+
+    const handlePlaneViewZoom = useCallback((direction: number) => {
+        selectionDispatch({
+            type: 'planeViewZoom',
+            direction
+        })
+    }, [selectionDispatch])
+    const handlePlaneViewBrighten = useCallback((direction: number) => {
+        selectionDispatch({
+            type: 'planeViewBrighten',
+            direction
+        })
+    }, [selectionDispatch])
+    const handlePlaneViewScaleArrows = useCallback((direction: number) => {
+        selectionDispatch({
+            type: 'planeViewScaleArrows',
+            direction
+        })
+    }, [selectionDispatch])
+    const handlePlaneViewAdjustArrowStride = useCallback((direction: number) => {
+        selectionDispatch({
+            type: 'planeViewAdjustArrowStride',
+            direction
+        })
+    }, [selectionDispatch])
+
+    return (
+        <div key="plane-views">
+            <h3>Plane views</h3>
+            <ZoomFactorControl
+                value={selection.planeViewOpts.zoomFactor}
+                onZoom={handlePlaneViewZoom}
+            />
+            <div>&nbsp;</div>
+            <BrightnessFactorControl
+                value={selection.planeViewOpts.brightnessFactor}
+                onBrighten={handlePlaneViewBrighten}
+            />
+            <div>&nbsp;</div>
+            <ArrowScaleFactorControl
+                value={selection.planeViewOpts.arrowScaleFactor}
+                onScaleArrows={handlePlaneViewScaleArrows}
+            />
+            <div>&nbsp;</div>
+            <ArrowStrideControl
+                value={selection.planeViewOpts.arrowStride}
+                onAdjustArrowStride={handlePlaneViewAdjustArrowStride}
+            />
+        </div>
+    )
+}
+
+export default PlaneViewControls

--- a/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
+++ b/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
@@ -1,0 +1,53 @@
+import { Checkbox } from '@material-ui/core';
+import React, { FunctionComponent, useCallback } from 'react';
+import { WorkspaceViewData } from 'VolumeViewData';
+import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+
+type SurfaceSelectionControlProps = {
+    data: WorkspaceViewData
+    selection: WorkspaceViewSelection
+    selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+const SurfaceSelectionControls: FunctionComponent<SurfaceSelectionControlProps> = (props: SurfaceSelectionControlProps) => {
+    const { data, selection, selectionDispatch } = props
+
+    const handleToggleVisibleSurface = useCallback((e: React.ChangeEvent<{
+        value: unknown
+    }>) => {
+        const surfaceName = e.target.value as string
+        selectionDispatch({
+            type: 'toggleVisibleSurface',
+            surfaceName
+        })
+    }, [selectionDispatch])
+
+
+    return (
+        <div key="surfaces">
+            <h3>Surfaces</h3>
+            {
+                data.surfaces.map(x => (
+                    <div key={x.name}>
+                        <div key="surface">Surface: {x.name}</div>
+                        <div key="show">
+                            <Checkbox
+                                value={x.name}
+                                checked={(selection.visibleSurfaceNames || []).includes(x.name)}
+                                onChange={handleToggleVisibleSurface}
+                            /> show surface
+                        </div>
+                        <div key="surface-vector-fields">
+                            {/* todo */}
+                        </div>
+                        <div key="surface-scalar-fields">
+                            {/* todo */}
+                        </div>
+                    </div>
+                ))
+            }
+        </div>
+    )
+}
+
+export default SurfaceSelectionControls

--- a/gui/src/WorkspaceView/controls/ThreeDSceneControls.tsx
+++ b/gui/src/WorkspaceView/controls/ThreeDSceneControls.tsx
@@ -1,0 +1,54 @@
+import { Checkbox } from '@material-ui/core';
+import React, { FunctionComponent, useCallback } from 'react';
+import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+
+type ThreeDSceneControlProps = {
+    selection: WorkspaceViewSelection
+    selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+const ThreeDSceneControls: FunctionComponent<ThreeDSceneControlProps> = (props: ThreeDSceneControlProps) => {
+    const {selection, selectionDispatch} = props
+
+    const handleToggleShowReferencePlanes = useCallback(() => {
+        selectionDispatch({
+            type: 'toggleShowReferencePlanes'
+        })
+    }, [selectionDispatch])
+    const handleToggleTransparentReferencePlanes = useCallback(() => {
+        selectionDispatch({
+            type: 'toggleTransparentReferencePlanes'
+        })
+    }, [selectionDispatch])
+    const handleToggleShowReferenceLines = useCallback(() => {
+        selectionDispatch({
+            type: 'toggleShowReferenceLines'
+        })
+    }, [selectionDispatch])
+
+    return (
+        <div key="3d-scene">
+            <h3>3D scene</h3>
+            <div>
+                <Checkbox
+                    checked={selection.scene3DOpts.showReferencePlanes}
+                    onChange={handleToggleShowReferencePlanes}
+                /> Show reference planes
+            </div>
+            <div>
+                <Checkbox
+                    checked={selection.scene3DOpts.transparentReferencePlanes}
+                    onChange={handleToggleTransparentReferencePlanes}
+                /> Transparent reference planes
+            </div>
+            <div>
+                <Checkbox
+                    checked={selection.scene3DOpts.showReferenceLines}
+                    onChange={handleToggleShowReferenceLines}
+                /> Show reference lines
+            </div>
+        </div>
+    )
+}
+
+export default ThreeDSceneControls


### PR DESCRIPTION
Fixes #2.

Per our conversation, grid-related controls (vector and scalar fields, 3d scene controls, and controls for the plane views) are only displayed when there is a grid selected. The grid selection dropdown is displayed only if there are multiple possible grids to select. Grid control selections are preserved when re-selecting a grid after de-selecting it (at least that's how things currently work).

While I was in the neighborhood, I split the different sections of the control panel into separate files. My hope is that this will make it a bit easier to read the individual sections of code. We might need to back this out if different controls require more interaction other than what's mediated by the selection state (although hopefully that would be handled by the selection dispatch and reducer).

Examples:
https://www.figurl.org/f?v=http://localhost:3000&d=e9d66edac2246a9db4aca6c515d4b79aaa450796&channel=flatiron1&label=Test%20volumeview%20workspace --> Demonstration of the workspace with a grid
https://www.figurl.org/f?v=http://localhost:3000&d=eae895acdc1de9b70be60849600022a7a6404e6b&channel=flatiron1&label=red%20blood%20cell --> demonstration of the workspace when there is no grid to select