### PR TITLE
Rework surface field selection. Fixes issues 8, 9, 10, 14.

### DIFF
--- a/examples/example_paired_rbc_surfaces.py
+++ b/examples/example_paired_rbc_surfaces.py
@@ -1,0 +1,34 @@
+import kachery_client as kc
+import volumeview as vv
+import numpy as np
+
+def main():
+    # your node needs to be a member of the flatiron1 kachery channel to obtain this file
+    vtk_uri = 'sha1://e54d59b5f12d226fdfe8a0de7d66a3efd1b83d69/rbc_001.vtk'
+    vtk_path = kc.load_file(vtk_uri)
+
+    vertices, faces = vv._parse_vtk_unstructured_grid(vtk_path)
+    vertices2 = np.array([[-v[0] + 10, -v[1] + 2, v[2]] for v in vertices], np.float32)
+
+    # vertices is n x 3 array of vertex locations
+    # faces is m x 3 array of vertex indices for triangular mesh
+
+    W = vv.Workspace()
+    S = W.add_surface(name='red-blood-cell', vertices=vertices, faces=faces)
+    W.add_surface_scalar_field(name='scalarX', surface=S, data=vertices[:, 0])
+    W.add_surface_scalar_field(name='scalarY', surface=S, data=vertices[:, 1])
+    W.add_surface_scalar_field(name='scalarZ', surface=S, data=vertices[:, 2])
+
+    mirrored_surface = W.add_surface(name="mirrored-rbc", vertices=vertices2, faces=faces)
+    W.add_surface_scalar_field(name='scalarX', surface=mirrored_surface, data=vertices[:, 0])
+    W.add_surface_scalar_field(name='scalarY', surface=mirrored_surface, data=vertices[:, 1])
+    W.add_surface_scalar_field(name='scalarZ', surface=mirrored_surface, data=vertices[:, 2])
+
+    F = W.create_figure()
+    url = F.url(label='red blood cell')
+    print(url)
+    # 1/6/2022
+    # https://www.figurl.org/f?v=gs://figurl/volumeview-2&d=a997d5dd425a92ee67aa750aa48a9d9c3193f474&channel=flatiron1&label=red%20blood%20cell
+
+if __name__ == '__main__':
+    main()

--- a/gui/src/WorkspaceView/WorkspaceViewControlPanel.tsx
+++ b/gui/src/WorkspaceView/WorkspaceViewControlPanel.tsx
@@ -1,9 +1,9 @@
-import { Checkbox } from '@material-ui/core';
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent } from 'react';
 import { WorkspaceViewData } from 'VolumeViewData';
 import GridFieldControls from './controls/GridFieldControls';
 import GridSelectionControls from './controls/GridSelectionControls';
 import PlaneViewControls from './controls/PlaneViewControls';
+import SurfaceSelectionControls from './controls/SurfaceSelectionControls';
 import ThreeDSceneControls from './controls/ThreeDSceneControls';
 import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from './workspaceViewSelectionReducer';
 
@@ -16,38 +16,6 @@ type Props = {
 }
 
 const WorkspaceViewControlPanel: FunctionComponent<Props> = ({data, selection, selectionDispatch}) => {
-    const handleToggleVisibleSurface = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const surfaceName = e.target.value as string
-        selectionDispatch({
-            type: 'toggleVisibleSurface',
-            surfaceName
-        })
-    }, [selectionDispatch])
-    const handleToggleSelectSurfaceScalarField = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const surfaceScalarFieldName = e.target.value as string
-        const surfaceName = data.surfaceScalarFields.filter(y => (y.name === surfaceScalarFieldName))[0].surfaceName
-        selectionDispatch({
-            type: 'toggleSelectedSurfaceScalarField',
-            surfaceName,
-            surfaceScalarFieldName
-        })
-    }, [selectionDispatch, data.surfaceScalarFields])
-    const handleToggleSelectSurfaceVectorField = useCallback((e: React.ChangeEvent<{
-        value: unknown
-    }>) => {
-        const surfaceVectorFieldName = e.target.value as string
-        const surfaceName = data.surfaceVectorFields.filter(y => (y.name === surfaceVectorFieldName))[0].surfaceName
-        selectionDispatch({
-            type: 'toggleSelectedSurfaceVectorField',
-            surfaceName,
-            surfaceVectorFieldName
-        })
-    }, [selectionDispatch, data.surfaceVectorFields])
-
     const gridControls = selection.gridName ? [<GridFieldControls
         data={data}
         selection={selection}
@@ -75,69 +43,15 @@ const WorkspaceViewControlPanel: FunctionComponent<Props> = ({data, selection, s
                 />
             }
 
-            {/* Surfaces */}
-            <div key="surfaces">
-                {
-                    data.surfaces.map(x => {
-                        const surfaceVectorFields = data.surfaceVectorFields.filter(y => (y.surfaceName === x.name))
-                        const surfaceScalarFields = data.surfaceScalarFields.filter(y => (y.surfaceName === x.name))
-                        return (
-                            <div key={x.name}>
-                                <h3 key="surface">Surface: {x.name}</h3>
-                                <div key="show">
-                                    <Checkbox
-                                        value={x.name}
-                                        checked={(selection.visibleSurfaceNames || []).includes(x.name)}
-                                        onChange={handleToggleVisibleSurface}
-                                    /> show surface
-                                </div>
-                                <div key="surface-vector-fields">
-                                    {
-                                        surfaceVectorFields.length > 0 && (
-                                            <span>
-                                                <h4>Surface vector fields</h4>
-                                                {
-                                                    surfaceVectorFields.map(y => (
-                                                        <div key={y.name}>
-                                                            <Checkbox
-                                                                value={y.name}
-                                                                checked={selection.selectedSurfaceVectorFieldNames[x.name] === y.name}
-                                                                onChange={handleToggleSelectSurfaceVectorField}
-                                                            />
-                                                            {y.name}
-                                                        </div>
-                                                    ))
-                                                }
-                                            </span>
-                                        )
-                                    }
-                                </div>
-                                <div key="surface-scalar-fields">
-                                    {
-                                        surfaceScalarFields.length > 0 && (
-                                            <span>
-                                                <h4>Surface scalar fields</h4>
-                                                {
-                                                    surfaceScalarFields.map(y => (
-                                                        <div key={y.name}>
-                                                            <Checkbox
-                                                                value={y.name}
-                                                                checked={selection.selectedSurfaceScalarFieldNames[x.name] === y.name}
-                                                                onChange={handleToggleSelectSurfaceScalarField}
-                                                            />
-                                                            {y.name}
-                                                        </div>
-                                                    ))
-                                                }
-                                            </span>
-                                        )
-                                    }
-                                </div>
-                            </div>
-                        )
-                    })
-                }
-            </div>
+            {/* Surfaces & their Fields */}
+            {
+                data.surfaces.length > 0 &&
+                <SurfaceSelectionControls
+                    data={data}
+                    selection={selection}
+                    selectionDispatch={selectionDispatch}
+                />
+            }
 
             {gridControls}
         </div>

--- a/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
+++ b/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
@@ -47,7 +47,6 @@ const SurfaceSelectionControls: FunctionComponent<SurfaceSelectionControlProps> 
     const fieldTtoggler = useCallback((name: string, fieldType: 'scalar' | 'vector') => {
         const type = fieldType === 'scalar' ? 'toggleSelectedSurfaceScalarField' : 'toggleSelectedSurfaceVectorField'
         const [ surfaceName, surfaceFieldName ] = name.split(separator)
-        console.log(`Dispatching for ${surfaceName} ${surfaceFieldName} from ${name}`)
         selectionDispatch({ type, surfaceName, surfaceFieldName })
     }, [selectionDispatch])
 

--- a/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
+++ b/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
@@ -1,0 +1,165 @@
+import { Checkbox } from '@material-ui/core';
+import React, { FunctionComponent, useCallback, useMemo } from 'react';
+import { WorkspaceSurfaceScalarField, WorkspaceSurfaceVectorField, WorkspaceViewData } from 'VolumeViewData';
+import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+
+const separator = '::'
+
+type SurfaceSelectionControlProps = {
+    data: WorkspaceViewData
+    selection: WorkspaceViewSelection
+    selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+type PerSurfaceControlsProps = {
+    name: string
+    displayed: boolean
+    scalarFields: WorkspaceSurfaceScalarField[]
+    vectorFields: WorkspaceSurfaceVectorField[]
+    selectedScalarFieldName?: string
+    selectedVectorFieldName?: string
+    visibilityCallback: any
+    selectedVectorFieldCallback: any
+    selectedScalarFieldCallback: any
+}
+
+type FieldSelectorProps = {
+    surfaceName: string
+    fields: WorkspaceSurfaceScalarField[] | WorkspaceSurfaceVectorField[]
+    selectedFieldName?: string
+    type: 'vector' | 'scalar'
+    callback: any
+}
+
+type ChangeEvent = React.ChangeEvent<{value: unknown}>
+
+const SurfaceSelectionControls: FunctionComponent<SurfaceSelectionControlProps> = (props: SurfaceSelectionControlProps) => {
+    const { data, selection, selectionDispatch } = props
+
+    const handleToggleVisibleSurface = useCallback((e: ChangeEvent) => {
+        const surfaceName = e.target.value as string
+        selectionDispatch({
+            type: 'toggleVisibleSurface',
+            surfaceName
+        })
+    }, [selectionDispatch])
+
+    const fieldTtoggler = useCallback((name: string, fieldType: 'scalar' | 'vector') => {
+        const type = fieldType === 'scalar' ? 'toggleSelectedSurfaceScalarField' : 'toggleSelectedSurfaceVectorField'
+        const [ surfaceName, surfaceFieldName ] = name.split(separator)
+        console.log(`Dispatching for ${surfaceName} ${surfaceFieldName} from ${name}`)
+        selectionDispatch({ type, surfaceName, surfaceFieldName })
+    }, [selectionDispatch])
+
+    const handleToggleSelectedScalarField = useCallback((e: ChangeEvent) => {
+        fieldTtoggler(e.target.value as string, 'scalar')
+    }, [fieldTtoggler])
+
+    const handleToggleSelectedVectorField = useCallback((e: ChangeEvent) => {
+        fieldTtoggler(e.target.value as string, 'vector')
+    }, [fieldTtoggler])
+
+    // This is probably not a huge performance boost, but we expect the underlying data to change rarely,
+    // while the selection state will change much more frequently.
+    // Might as well memoize the filtering that matches surfaces to fields, so we don't need to re-filter
+    // every time a selection state changes.
+    const surfacesWithFields = useMemo(() => (
+        data.surfaces.map(surface => {
+            return {
+                name: surface.name,
+                scalarFields: data.surfaceScalarFields.filter(field => field.surfaceName === surface.name),
+                vectorFields: data.surfaceVectorFields.filter(field => field.surfaceName === surface.name)
+            }
+        })
+    ), [data.surfaces, data.surfaceScalarFields, data.surfaceVectorFields])
+
+    const surfaces = useMemo(() => (surfacesWithFields.map(surface => {
+        return {
+            name: surface.name,
+            displayed: (selection.visibleSurfaceNames || []).includes(surface.name),
+            scalarFields: surface.scalarFields,
+            vectorFields: surface.vectorFields,
+            selectedScalarFieldName: selection.selectedSurfaceScalarFieldNames[surface.name],
+            selectedVectorFieldName: selection.selectedSurfaceVectorFieldNames[surface.name]
+        }
+    })), [surfacesWithFields, selection.selectedSurfaceVectorFieldNames, selection.selectedSurfaceScalarFieldNames, selection.visibleSurfaceNames])
+
+    return (
+        <div key="surfaces">
+            <h3>Surfaces</h3>
+            {
+                surfaces.map(surface => (
+                    <PerSurfaceControls
+                        name={surface.name}
+                        displayed={surface.displayed}
+                        scalarFields={surface.scalarFields}
+                        vectorFields={surface.vectorFields}
+                        selectedScalarFieldName={surface.selectedScalarFieldName}
+                        selectedVectorFieldName={surface.selectedVectorFieldName}
+                        visibilityCallback={handleToggleVisibleSurface}
+                        selectedScalarFieldCallback={handleToggleSelectedScalarField}
+                        selectedVectorFieldCallback={handleToggleSelectedVectorField}
+                    />
+                ))
+            }
+        </div>
+    )
+}
+
+const PerSurfaceControls: FunctionComponent<PerSurfaceControlsProps> = (surface: PerSurfaceControlsProps) => {
+    const { name, displayed, scalarFields, vectorFields, selectedScalarFieldName, selectedVectorFieldName, visibilityCallback, selectedVectorFieldCallback, selectedScalarFieldCallback } = surface
+    return (
+        <div key={name}>
+            <h3 key="surface">Surface: {name}</h3>
+            <div key="show">
+                <Checkbox
+                    value={name}
+                    checked={displayed}
+                    onChange={visibilityCallback}
+                /> show surface
+            </div>
+            {/* Vector field selector */}
+            {displayed && <FieldSelector
+                surfaceName={name}
+                fields={vectorFields}
+                selectedFieldName={selectedVectorFieldName}
+                type={'vector'}
+                callback={selectedVectorFieldCallback}
+            />}
+            {/* Scalar field selector */}
+            {displayed && <FieldSelector
+                surfaceName={name}
+                fields={scalarFields}
+                selectedFieldName={selectedScalarFieldName}
+                type={'scalar'}
+                callback={selectedScalarFieldCallback}
+            />}
+        </div>
+    )
+}
+
+const FieldSelector: FunctionComponent<FieldSelectorProps> = (props: FieldSelectorProps) => {
+    const { surfaceName, fields, selectedFieldName, type, callback } = props
+    if (fields.length === 0) return (<span />)
+    return (
+        <div key={`surface-${type}-fields`}>
+            <span>
+                <h4>Surface {type} fields</h4>
+                {
+                    fields.map(field => (
+                        <div key={field.name}>
+                            <Checkbox
+                                value={`${surfaceName}${separator}${field.name}`}
+                                checked={selectedFieldName === field.name}
+                                onChange={callback}
+                            />
+                            {field.name}
+                        </div>
+                    ))
+                }
+            </span>
+        </div>
+    )
+}
+
+export default SurfaceSelectionControls

--- a/gui/src/WorkspaceView/workspaceViewSelectionReducer.ts
+++ b/gui/src/WorkspaceView/workspaceViewSelectionReducer.ts
@@ -102,11 +102,11 @@ export type WorkspaceViewSelectionAction = {
     panelLayoutMode: PanelLayoutMode
 } | {
     type: 'toggleSelectedSurfaceScalarField'
-    surfaceScalarFieldName: string
+    surfaceFieldName: string
     surfaceName: string
 } | {
     type: 'toggleSelectedSurfaceVectorField'
-    surfaceVectorFieldName: string
+    surfaceFieldName: string
     surfaceName: string
 }
 
@@ -159,22 +159,22 @@ export const workspaceViewSelectionReducer = (s: WorkspaceViewSelection, a: Work
     else if (a.type === 'toggleSelectedSurfaceScalarField') {
         const name = s.selectedSurfaceScalarFieldNames[a.surfaceName]
         const X = {...s.selectedSurfaceScalarFieldNames}
-        if ((name) && (name === a.surfaceScalarFieldName)) {
+        if ((name) && (name === a.surfaceFieldName)) {
             X[a.surfaceName] = undefined
         }
         else {
-            X[a.surfaceName] = a.surfaceScalarFieldName
+            X[a.surfaceName] = a.surfaceFieldName
         }
         return {...s, selectedSurfaceScalarFieldNames: X}
     }
     else if (a.type === 'toggleSelectedSurfaceVectorField') {
         const name = s.selectedSurfaceVectorFieldNames[a.surfaceName]
         const X = {...s.selectedSurfaceVectorFieldNames}
-        if ((name) && (name === a.surfaceVectorFieldName)) {
+        if ((name) && (name === a.surfaceFieldName)) {
             X[a.surfaceName] = undefined
         }
         else {
-            X[a.surfaceName] = a.surfaceVectorFieldName
+            X[a.surfaceName] = a.surfaceFieldName
         }
         return {...s, selectedSurfaceVectorFieldNames: X}
     }


### PR DESCRIPTION
Working example:
https://www.figurl.org/f?v=gs://figurl/volumeview-2&d=a997d5dd425a92ee67aa750aa48a9d9c3193f474&channel=flatiron1&label=red%20blood%20cell (as https://www.figurl.org/f?v=http://localhost:3000&d=a997d5dd425a92ee67aa750aa48a9d9c3193f474&channel=flatiron1&label=red%20blood%20cell with this branch running)

This PR adddresses the following issues:

- #8 is a code-cleanup issue to modularize rendering of surface selection controls
- #9 suppresses display of surface controls when no surfaces are in the workspace
- #10 hides field selection controls for surfaces not currently displayed
- #14 is a bug in the case where multiple surfaces have fields with the same name

The following changes have been made:

- Added [examples/example_paired_rbc_surfaces.py](https://github.com/magland/volumeview/compare/control-panel-revisions?expand=1#diff-2919d62bd3c30086bf2331afa374d0ad76fbd6e0e9b9b065938a1b3cd4c44231) which generates the two-surface example at the top of this PR
- Recreated [gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx](https://github.com/magland/volumeview/compare/control-panel-revisions?expand=1#diff-b2fc60e8d492adeaa7aed57ea9dc7eacef2e8b0196c7904d8c5a4fe9cf35f617) and moved substantial parts of [gui/src/WorkspaceView/WorkspaceViewControlPanel.tsx](https://github.com/magland/volumeview/compare/control-panel-revisions?expand=1#diff-9d82154776d888ef680d91a8bebab191473d48e28205365368b5cedcd8f2213f) into it, with changes to modularize
- Changed names of some variables in [gui/src/WorkspaceView/workspaceViewSelectionReducer.ts](https://github.com/magland/volumeview/compare/control-panel-revisions?expand=1#diff-21f27d116d2e626ab8cfa221e4360960eb662be0594f2246eee423ec480116e7) to allow easier calling from the front-end.

The following behaviors were manually verified using the example above:

- Surfaces correctly show and hide based on surface selection
  - Surface scalar field selection controls are hidden when the surface they belong to is hidden
  - Surface field selection persists when hiding and then re-showing a surface
- The correct surface's field is displayed/hidden when the checkboxes are modified

Not verified:

 - Issue #9, because I don't actually have an example with a grid but no surface. I don't know that this was ever actually tested--the functionality was added incidentally in PR #4-- but as it's a one-line change, I'm assuming it's correct.