### PR TITLE
Implement surface field selection sync.

### DIFF
--- a/gui/src/WorkspaceView/controls/Controls.css
+++ b/gui/src/WorkspaceView/controls/Controls.css
@@ -1,0 +1,3 @@
+.slider {
+    padding-left: 15px;
+}

--- a/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
+++ b/gui/src/WorkspaceView/controls/SurfaceSelectionControls.tsx
@@ -1,7 +1,9 @@
-import { Checkbox } from '@material-ui/core';
+import { Checkbox, FormControlLabel, FormGroup, Typography } from '@material-ui/core';
+import Switch from '@material-ui/core/Switch';
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import { WorkspaceSurfaceScalarField, WorkspaceSurfaceVectorField, WorkspaceViewData } from 'VolumeViewData';
 import { WorkspaceViewSelection, WorkspaceViewSelectionAction } from '../workspaceViewSelectionReducer';
+import "./Controls.css";
 
 const separator = '::'
 
@@ -9,6 +11,11 @@ type SurfaceSelectionControlProps = {
     data: WorkspaceViewData
     selection: WorkspaceViewSelection
     selectionDispatch: (a: WorkspaceViewSelectionAction) => void
+}
+
+type SyncSwitchProps = {
+    syncOn: boolean
+    callback: any
 }
 
 type PerSurfaceControlsProps = {
@@ -93,6 +100,8 @@ const SurfaceSelectionControls: FunctionComponent<SurfaceSelectionControlProps> 
         })
     }, [selectionDispatch])
 
+    const handleToggleSurfaceSelectionSync = useCallback(() => {selectionDispatch({type: 'toggleSurfaceSelectionSynchronization'})}, [selectionDispatch])
+
     const fieldToggler = useCallback((name: string, fieldType: 'scalar' | 'vector') => {
         const type = fieldType === 'scalar' ? 'toggleSelectedSurfaceScalarField' : 'toggleSelectedSurfaceVectorField'
         // The reducer doesn't actually know the names of non-displayed surfaces--it doesn't see the data.
@@ -114,6 +123,7 @@ const SurfaceSelectionControls: FunctionComponent<SurfaceSelectionControlProps> 
     return (
         <div key="surfaces">
             <h3>Surfaces</h3>
+            <SyncSwitch syncOn={selection.synchronizeSurfaceFieldSelection} callback={handleToggleSurfaceSelectionSync} />
             {
                 selection.synchronizeSurfaceFieldSelection && <SynchronizedFieldSelectionControls
                     scalarFields={allFieldNames.scalarFields}
@@ -141,6 +151,18 @@ const SurfaceSelectionControls: FunctionComponent<SurfaceSelectionControlProps> 
                 ))
             }
         </div>
+    )
+}
+
+const SyncSwitch: FunctionComponent<SyncSwitchProps> = (props: SyncSwitchProps) => {
+    const { syncOn, callback } = props
+    return (
+        <FormGroup className={"slider"}>
+            <FormControlLabel
+                control={ <Switch checked={syncOn} size={"small"} onChange={() => callback()} /> }
+                label={ <Typography variant="caption">Sync selected fields</Typography> }
+            />
+        </FormGroup>
     )
 }
 

--- a/gui/src/WorkspaceView/workspaceViewSelectionReducer.ts
+++ b/gui/src/WorkspaceView/workspaceViewSelectionReducer.ts
@@ -168,8 +168,16 @@ export const workspaceViewSelectionReducer = (s: WorkspaceViewSelection, a: Work
     else if (a.type === 'toggleSelectedSurfaceVectorField') {
         const updatedSelections = updateFieldSelection(s.selectedSurfaceVectorFieldNames, a.surfaceFieldName, a.surfaceNames)
         return {...s, selectedSurfaceVectorFieldNames: updatedSelections}
-    } else if (a.type === 'toggleSurfaceSelectionSynchronization') { 
-        return {...s, synchronizeSurfaceFieldSelection: !s.synchronizeSurfaceFieldSelection}
+    } else if (a.type === 'toggleSurfaceSelectionSynchronization') {
+        // If moving from a synchronized state, keep all existing selections.
+        if (s.synchronizeSurfaceFieldSelection) return {...s, synchronizeSurfaceFieldSelection: false}
+
+        // If moving *to* a synchronized state, clear any existing selections that are not synchronized.
+        const selectedScalarFields = Object.values(s.selectedSurfaceScalarFieldNames)
+        const scalarSelections = selectedScalarFields.every((f) => f === selectedScalarFields[0]) ? s.selectedSurfaceScalarFieldNames : {}
+        const selectedVectorFields = Object.values(s.selectedSurfaceVectorFieldNames)
+        const vectorSelections = selectedVectorFields.every(f => f === selectedVectorFields[0]) ? s.selectedSurfaceVectorFieldNames : {}
+        return {...s, selectedSurfaceScalarFieldNames: scalarSelections, selectedSurfaceVectorFieldNames: vectorSelections, synchronizeSurfaceFieldSelection: true}
     }
     else {
         throw Error('Unexpected action type')
@@ -181,7 +189,6 @@ const updateFieldSelection = (selections: {[surface: string]: string | undefined
 
     const newSelections: { [key: string]: string | undefined } = {...selections}
     surfacesToUpdate.forEach(surfaceName => {
-        console.log(`Updating ${surfaceName} to ${newSelectionName}`)
         const currentSelection = selections[surfaceName]
         newSelections[surfaceName] = currentSelection === newSelectionName ? undefined : newSelectionName
     })

--- a/gui/src/WorkspaceView/workspaceViewSelectionReducer.ts
+++ b/gui/src/WorkspaceView/workspaceViewSelectionReducer.ts
@@ -161,7 +161,6 @@ export const workspaceViewSelectionReducer = (s: WorkspaceViewSelection, a: Work
         return {...s, panelLayoutMode: a.panelLayoutMode}
     }
     else if (a.type === 'toggleSelectedSurfaceScalarField') {
-        // TODO: make behavior depend on state of synchronizeSurfaceFieldSelection variable rather than input surface name?
         const updatedSelections = updateFieldSelection(s.selectedSurfaceScalarFieldNames, a.surfaceFieldName, a.surfaceNames)
         return {...s, selectedSurfaceScalarFieldNames: updatedSelections}
     }


### PR DESCRIPTION
Example: https://www.figurl.org/f?v=http://localhost:3000&d=84a084a615ee9dfa0781a09b028ad5438b9ebb83&channel=flatiron1&label=miniwasp_surface_example2

This PR:

- Adds a surface-selection synchronization value to the `WorkspaceViewSelection` state object
- Adds reducer methods to handle this
- Modifies reducer methods for modifying field selection state so that they can apply to multiple surfaces simultaneously
- Adds a slider control to the `SurfaceSelectionControls` to toggle synchronization state
- Adds display logic to `SurfaceSelectionControls` to position the surface field selection controls appropriately when state is synced
- Adds a local css file for the `WorkspaceView` controls to hold custom styling (currently only used to position the slider)

There are a few subtleties about the behavior that are worth noting in this implementation.

- This submission modifies the selected field for all surfaces--regardless of whether the surface is visible, or even whether it has a field by that name defined. (For display, this has the same effect for that surface as having no selected field, since none of its fields match the selected one.)
- The selection state is not aware of the existence of surfaces which aren't displayed, so the `SurfaceSelectionControls` need to read the universe of surfaces from the data and pass the surfaces to modify into the reducer.
- When toggling sync state, currently turning off sync all surfaces' selected field set to the last field selected in the synchronized state. (i.e. if you sync, select field 'r', and then desync, every surface will continue to have 'r' selected, which you can subsequently modify). When activating synchronization, if all surfaces have the same field selected, it remains selected; otherwise, all selections are cleared. I expect this is the most natural behavior. (The main motivation for clearing selection state when selections are heterogeneous is that if you turn on sync, then select a field that one of the surfaces had selected, it'll toggle off for that surface while toggling on for all the others.)

Open questions:

1. As currently implemented, every surface's selected field is reset to match the global state. An alternative implementation would keep a separate globally-selected-field state, and use display logic to determine which one to show. This would allow toggling while preserving selections on individual surfaces, but would disallow using this feature to easily toggle all of the surfaces' selected fields and then explore different options on one of them (since turning off sync would revert all the others). Which is a more desirable feature for our users?
2. Should we separate selection-synchronization for vector and scalar fields?